### PR TITLE
exposed a new MLBM argument for filtering low occurrence aa calls;

### DIFF
--- a/conf/tools.config
+++ b/conf/tools.config
@@ -11,3 +11,13 @@ params {
     coi_method_options = ["NAIVE_INT_METHOD","NAIVE_QUANTILE_METHOD"]
     coi_method = "NAIVE_INT_METHOD"
 }
+
+process {
+    withName: 'MLBM_WRAPPER' {
+        // Assign a closure which returns a string
+        ext.args = { [
+            params.mlbm_wrapper_aa_specimen_occurence_cut_off ? "--aa_sample_occurence_cut_off ${params.mlbm_wrapper_aa_specimen_occurence_cut_off}" : ""
+        ].join(" ")
+        }
+    }
+}

--- a/modules/local/mlbm_wrapper.nf
+++ b/modules/local/mlbm_wrapper.nf
@@ -16,8 +16,13 @@ process MLBM_WRAPPER {
 
 
     script:
+    def extra_args = task.ext.args ? task.ext.args : ''
+
     """
-    Rscript ${projectDir}/bin/PGEcore/scripts/MultiLociBiallelicModel_wrapper/MultiLociBiallelicModel_wrapper.R \\
-        --aa_calls ${aa_calls} --loci_group_table ${loci_group_table} --mlaf_output "${aa_calls.getBaseName(3)}.aa_mlaf.tsv"
+    Rscript ${projectDir}/bin/PGEcore/scripts/MultiLociBiallelicModel_wrapper/MultiLociBiallelicModel_wrapper.R \
+        --aa_calls ${aa_calls} \
+        --loci_group_table ${loci_group_table} \
+        --mlaf_output "${aa_calls.getBaseName(3)}.aa_mlaf.tsv"\
+        ${extra_args}
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,6 +28,7 @@ params {
     translate_loci_extra_args   = ""
     naive_slaf_method           = "read_count_prop"
     coi_method                  = "NAIVE_INT_METHOD"
+    mlbm_wrapper_aa_specimen_occurence_cut_off = null
 
     // Boilerplate options
     params.input                 = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -183,7 +183,14 @@
                 "mlaf_method_options": {
                     "type": "array",
                     "description": "method options for multi locus allele frequency estimates.",
-                    "default": "['MLBM', 'FEM']",
+                    "default": "['MLBM', 'FEM', 'NAIVE']",
+                    "hidden": true,
+                    "fa_icon": "fas fa-users-cog"
+                },
+                "mlbm_wrapper_aa_specimen_occurence_cut_off": {
+                    "type": "integer",
+                    "description": "when running MLBM, a cut off value for filtering amino acid calls.",
+                    "default": "null",
                     "hidden": true,
                     "fa_icon": "fas fa-users-cog"
                 },


### PR DESCRIPTION
Exposed an argument to MLBM wrapper to be able filter low occurrence amino acid calls, can help save loci if non-biallelic by just 1 occurence of a 2nd alt
