### PR TITLE
add instructions for pulling image with different platform and remove…

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Run the workflow with `-profile docker` so Nextflow uses that container.
 **Note:** If you are using an Apple Silicon Mac (M1/M2/M3) and encounter an error such as `no matching manifest for linux/arm64/v8 in the manifest list entries` please pull and run the container using the following command
 
 ```bash
-docker pull --platform linux/amd64 plasmogenepi/plasmodiumdrugres:latest
+docker pull --platform linux/amd64 plasmogenepi/plasmodiumdrugres:main
 ```
 
 The most simple way to run this pipeline is by using a [Portable Microhaplotype Object (PMO)](https://plasmogenepi.github.io/PMO_Docs/) file. To maximize flexibility, the pipeline also allows users to provide a PMO with reference sequences separately, or to supply an allele table with panel information in a separate file.

--- a/README.md
+++ b/README.md
@@ -62,10 +62,17 @@ git submodule update --init --recursive
 The simplest way to get the software you need is to use [Docker](https://www.docker.com/get-started). Install Docker, then pull the pipeline image (do this when you first set up, and again when you upgrade the pipeline or want the latest image):
 
 ```bash
-docker pull plasmogenepi/plasmodiumdrugres
+docker pull plasmogenepi/plasmodiumdrugres:main
 ```
 
-Run the workflow with `-profile docker` so Nextflow uses that container.
+Run the workflow with `-profile docker` so Nextflow uses that container. 
+
+
+**Note:** If you are using an Apple Silicon Mac (M1/M2/M3) and encounter an error such as `no matching manifest for linux/arm64/v8 in the manifest list entries` please pull and run the container using the following command 
+
+```bash
+docker pull --platform linux/amd64 plasmogenepi/plasmodiumdrugres:latest
+```
 
 The most simple way to run this pipeline is by using a [Portable Microhaplotype Object (PMO)](https://plasmogenepi.github.io/PMO_Docs/) file. To maximize flexibility, the pipeline also allows users to provide a PMO with reference sequences separately, or to supply an allele table with panel information in a separate file.
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,9 @@ The simplest way to get the software you need is to use [Docker](https://www.doc
 docker pull plasmogenepi/plasmodiumdrugres:main
 ```
 
-Run the workflow with `-profile docker` so Nextflow uses that container. 
+Run the workflow with `-profile docker` so Nextflow uses that container.
 
-
-**Note:** If you are using an Apple Silicon Mac (M1/M2/M3) and encounter an error such as `no matching manifest for linux/arm64/v8 in the manifest list entries` please pull and run the container using the following command 
+**Note:** If you are using an Apple Silicon Mac (M1/M2/M3) and encounter an error such as `no matching manifest for linux/arm64/v8 in the manifest list entries` please pull and run the container using the following command
 
 ```bash
 docker pull --platform linux/amd64 plasmogenepi/plasmodiumdrugres:latest

--- a/nextflow.config
+++ b/nextflow.config
@@ -105,6 +105,7 @@ profiles {
         apptainer.enabled       = false
         docker.runOptions       = '-u $(id -u):$(id -g)'
         process.container       = "plasmogenepi/plasmodiumdrugres"
+        process.containerOptions = '--platform linux/amd64'
     }
     arm64 {
         process.arch            = 'arm64'

--- a/nextflow.config
+++ b/nextflow.config
@@ -105,7 +105,6 @@ profiles {
         apptainer.enabled       = false
         docker.runOptions       = '-u $(id -u):$(id -g)'
         process.container       = "plasmogenepi/plasmodiumdrugres"
-        process.containerOptions = '--platform linux/amd64'
     }
     arm64 {
         process.arch            = 'arm64'


### PR DESCRIPTION
This is a temporary fix for instructions on pulling the docker image and a note if the platform doesn't match. I have added an issue for handling multi platform builds

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/plasmodiumdrugres/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/plasmodiumdrugres _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
